### PR TITLE
Fixed an index out of bounds error.

### DIFF
--- a/namesgenerator.js
+++ b/namesgenerator.js
@@ -93,6 +93,6 @@ function randnum(n) {
 }
 
 function randelem(a) {
-  return a[randnum(a.length)];
+  return a[randnum(a.length - 1)];
 }
 


### PR DESCRIPTION
Until now, the call to `randnum` returned a number between `0` and the length of the array, which sometimes caused the module to use `undefined` as adjective or person name. By reducing the maximally possible value by 1 this issue is solved.
